### PR TITLE
post: How Tech Elites Form — Systems, Signals, and Loops

### DIFF
--- a/_posts/2026-05-10-how-tech-elites-form-systems-signals-loops.md
+++ b/_posts/2026-05-10-how-tech-elites-form-systems-signals-loops.md
@@ -1,0 +1,60 @@
+
+# How Tech Elites Form: Systems, Signals, and Loops
+
+Every senior engineer who's been turned down for Staff has asked the same question: "What am I missing?" They ship features. They mentor juniors. They review PRs. They're technically excellent. And yet, the promotion committee says no.
+
+They're not missing skills. They're missing the system.
+
+## The System Nobody Explained to You
+
+The Principal and Staff ladder isn't a reward for being a better Senior. It's a fundamentally different job measured against a fundamentally different rubric. If you approach it with a Senior mindset — write more code, ship faster, debug harder — you're optimizing for the wrong thing.
+
+The actual Principal/Staff rubrics measure three dimensions that most engineers never see documented:
+
+**Decision scope.** At Senior, you make decisions that affect your team's codebase. At Staff, your decisions shape how multiple teams build software for quarters at a time. At Principal, your decisions influence the technical direction of an entire organization — sometimes an entire company. The question the committee asks isn't "did they make good decisions?" It's "at what altitude did those decisions operate?"
+
+**Cross-org impact.** Senior engineers create impact within their team's charter. Staff engineers create impact that crosses team boundaries — a migration strategy adopted by four teams, a reliability framework that reduced incidents across a division, a technical design that eliminated months of duplicated work across the organization. If your impact can be fully captured by your team's sprint review, it's not Staff-level impact.
+
+**Authored design docs that became organizational artifacts.** This is the one that trips people up most. At Senior, you write design docs to communicate with your team. At Staff and Principal, your design docs become reference material that other teams cite, adopt, and build upon. The promotion committee isn't counting documentation — they're counting how many times your thinking became someone else's starting point.
+
+## The Signals That Matter
+
+Here's what most engineers get wrong: they think the Principal ladder measures technical depth. It doesn't — not directly. It measures whether your technical depth produces organizational leverage.
+
+A Staff engineer who architects a service mesh migration that saves twelve teams six months of effort each has created more leverage than a genius who personally rewrote every microservice to be 40% faster. The system doesn't measure how good you are. It measures how far your good reaches.
+
+This is why "just write more code" stops working as a promotion strategy around the Senior threshold. Code has linear leverage. Architecture decisions, design patterns, and technical strategy have multiplicative leverage. The ladder is designed to detect the multiplication factor.
+
+## The Loops That Compound
+
+What makes the system self-reinforcing is that these three signals form feedback loops:
+
+Design docs give you cross-org visibility. Cross-org visibility gives you access to bigger decisions. Bigger decisions generate material for more impactful design docs. Repeat.
+
+Engineers who break into this loop early — often by volunteering as the author of a postmortem that crossed team boundaries, or writing a technical proposal that solved a problem three teams shared — find themselves pulled into conversations at altitudes they didn't previously have access to. They didn't get promoted into the loop. They wrote their way into it.
+
+Conversely, engineers who stay heads-down, shipping excellent code within their team's remit, never trigger any of the three signals — regardless of how good their code is. They're invisible to the system by design.
+
+## This Isn't a Conspiracy
+
+It's tempting to frame this as politics or gatekeeping. It's neither. The Principal ladder exists because organizations don't scale through individual contribution — they scale through technical decisions that compound across teams. The promotion rubric is trying to identify the people whose decisions compound.
+
+The system is imperfect. It misses quiet architects who influence through conversation rather than documentation. It overweights visibility and underweights stability work that keeps systems running but leaves no artifact. But understanding the system — even to critique it — requires seeing it clearly first.
+
+## What To Do With This
+
+If you're a Senior engineer aiming for Staff:
+
+Stop optimizing for code output and start optimizing for decision surface area. Ask the question your team hasn't asked yet, then write the design doc that answers it. Circulate it to teams you don't work with. When they adopt your thinking, you've just generated the signal the committee is looking for.
+
+If you're already Staff and eyeing Principal:
+
+Your design docs should be shaping how your organization allocates engineering effort — not just how it builds software. The distinction matters. A doc that says "here's how we should implement this feature" is Staff-level. A doc that says "here's why we should stop building X and invest in Y instead, and here's the three-year technical trajectory" is Principal-level.
+
+If you're a Director or VP reading this:
+
+The engineers who understand this system are the ones you want at the table when you're making architectural bets. But you have engineers who don't understand it yet who are equally capable — they just haven't seen the rubric. Share it with them. The system works better when people know how it works.
+
+---
+
+The Principal ladder isn't a mystery. It's a measurement system optimized for organizational leverage. The engineers who ascend fastest aren't always the most technically gifted — they're the ones who understood the rules early enough to play the game they were already in.


### PR DESCRIPTION
New blog post on the Principal/Staff engineering ladder — what it actually measures and how the feedback loops compound career leverage.

- Decision scope, cross-org impact, authored design docs
- Why "write more code" stops working at Senior
- Practical guidance: Senior → Staff → Principal